### PR TITLE
remove async_forward_entry_setup

### DIFF
--- a/custom_components/samsungmdc/__init__.py
+++ b/custom_components/samsungmdc/__init__.py
@@ -1,4 +1,5 @@
 """The Samsung MDC integration."""
+
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
@@ -8,6 +9,7 @@ from .const import DOMAIN
 
 # For your initial PR, limit it to 1 platform.
 PLATFORMS = ["media_player"]
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Samsung MDC from a config entry."""
@@ -20,7 +22,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Forward the setup to the sensor platform.
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "media_player")
+        hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     )
     return True
 

--- a/custom_components/samsungmdc/config_flow.py
+++ b/custom_components/samsungmdc/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Samsung MDC."""
+
 import ipaddress
 from typing import Tuple
 
@@ -12,7 +13,16 @@ from voluptuous.error import Invalid
 from homeassistant import config_entries, exceptions
 from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME, CONF_TYPE, CONF_UNIQUE_ID
 
-from .const import CONF_DISPLAY_ID, DEFAULT_DISPLAY_ID, DEFAULT_NAME, DOMAIN, RESULT_CANNOT_CONNECT, RESULT_INV_DSPID, RESULT_INV_IP
+from .const import (
+    CONF_DISPLAY_ID,
+    DEFAULT_DISPLAY_ID,
+    DEFAULT_NAME,
+    DOMAIN,
+    RESULT_CANNOT_CONNECT,
+    RESULT_INV_DSPID,
+    RESULT_INV_IP,
+)
+
 
 async def test_connection(host: str, display_id: int) -> Tuple[str, str]:
     """Test the connection to a display and receive its serial."""
@@ -21,6 +31,7 @@ async def test_connection(host: str, display_id: int) -> Tuple[str, str]:
         (model,) = await mdc.model_name(display_id)
         return (serial_number, model)
 
+
 def is_valid_ip(ip: str):
     """Return True if IP address is valid."""
     try:
@@ -28,6 +39,7 @@ def is_valid_ip(ip: str):
             return True
     except ValueError:
         return False
+
 
 class SamsungMDCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Samsung MDC display entities."""
@@ -73,7 +85,7 @@ class SamsungMDCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         },
                     )
                 except (MDCTimeoutError, ConnectionRefusedError, OSError) as exc:
-                    self._errors["base"] = RESULT_CANNOT_CONNECT                
+                    self._errors["base"] = RESULT_CANNOT_CONNECT
 
         data_schema = vol.Schema(
             {
@@ -83,4 +95,6 @@ class SamsungMDCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
 
-        return self.async_show_form(step_id="user", data_schema=data_schema, errors=self._errors)
+        return self.async_show_form(
+            step_id="user", data_schema=data_schema, errors=self._errors
+        )

--- a/custom_components/samsungmdc/media_player.py
+++ b/custom_components/samsungmdc/media_player.py
@@ -12,14 +12,12 @@ from samsung_mdc.exceptions import (
 )
 
 from homeassistant import config_entries
-from homeassistant.components.media_player import DEVICE_CLASS_TV, MediaPlayerEntity
+from homeassistant.components.media_player import (
+    MediaPlayerEntity,
+    MediaPlayerDeviceClass,
+)
 from homeassistant.components.media_player.const import (
-    SUPPORT_SELECT_SOURCE,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_MUTE,
-    SUPPORT_VOLUME_SET,
-    SUPPORT_VOLUME_STEP,
+    MediaPlayerEntityFeature,
 )
 from homeassistant.const import (
     CONF_IP_ADDRESS,
@@ -71,15 +69,15 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 SUPPORT_MDC = (
-    SUPPORT_SELECT_SOURCE
-    | SUPPORT_VOLUME_SET
-    | SUPPORT_VOLUME_MUTE
-    | SUPPORT_TURN_OFF
-    | SUPPORT_TURN_ON
-    | SUPPORT_VOLUME_STEP
+    MediaPlayerEntityFeature.SELECT_SOURCE
+    | MediaPlayerEntityFeature.VOLUME_SET
+    | MediaPlayerEntityFeature.VOLUME_MUTE
+    | MediaPlayerEntityFeature.TURN_OFF
+    | MediaPlayerEntityFeature.TURN_ON
+    | MediaPlayerEntityFeature.VOLUME_STEP
 )
 
-# Map the input sources of the MDC protocol to names for Home Assistant 
+# Map the input sources of the MDC protocol to names for Home Assistant
 SOURCE_MAP = {
     INPUT_SOURCE.INPUT_SOURCE_STATE.NONE: SOURCE_NONE,
     INPUT_SOURCE.INPUT_SOURCE_STATE.S_VIDEO: SOURCE_S_VIDEO,
@@ -136,7 +134,7 @@ async def async_setup_entry(
 class SamsungMDCDisplay(MediaPlayerEntity):
     """Samsung MDC screen represented as a media_player."""
 
-    _attr_device_class = DEVICE_CLASS_TV
+    _attr_device_class = MediaPlayerDeviceClass.TV
     _attr_icon = "mdi:television"
 
     def __init__(
@@ -229,7 +227,7 @@ class SamsungMDCDisplay(MediaPlayerEntity):
         """If the state is currently assumed or not."""
         if self._is_awaiting_power_on:
             return True
-            
+
         return False
 
     async def async_update_sw_version(self):
@@ -315,7 +313,7 @@ class SamsungMDCDisplay(MediaPlayerEntity):
                 # Samsung displays are weird when powering on and might raise an non-issue exception in the parser,
                 # Let's assume the display is now turning on and will not respond (correctly) for the following 15 seconds.
                 continue
-    
+
         # If the power command is not ACK'd after 3 tries, it should be considered a failure.
         # We'll set the display offline and retry with a fresh connection next time.
         _LOGGER.error("MDC power command has not been ACK'd after 3 tries!")


### PR DESCRIPTION
The integration does not work anymore in 2025.6.0, because `async_forward_entry_setup` is deprecated.  This pull request fixes this.